### PR TITLE
chore: release 0.3.23, begin 0.3.24.dev0 development

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentic-sdlc-specify-cli"
-version = "0.3.23"
+version = "0.3.24.dev0"
 description = "Specify CLI (tikalk fork). Agentic SDLC toolkit for Spec-Driven Development with pre-installed extensions and AI integrations."
 requires-python = ">=3.11"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentic-sdlc-specify-cli"
-version = "0.3.22"
+version = "0.3.23"
 description = "Specify CLI (tikalk fork). Agentic SDLC toolkit for Spec-Driven Development with pre-installed extensions and AI integrations."
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
Automated release of 0.3.23.

This PR was created by the Release Trigger workflow. The git tag `agentic-sdlc-v0.3.23` has already been pushed and the release artifacts are being built.

Merging this PR will set `main` to `0.3.24.dev0` so that development installs are clearly marked as pre-release.