### PR TITLE
chore: release 0.5.5, begin 0.5.6.dev0 development

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentic-sdlc-specify-cli"
-version = "0.5.4"
+version = "0.5.5"
 description = "Specify CLI (tikalk fork). Agentic SDLC toolkit for Spec-Driven Development with pre-installed extensions and AI integrations."
 requires-python = ">=3.11"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentic-sdlc-specify-cli"
-version = "0.5.5"
+version = "0.5.6.dev0"
 description = "Specify CLI (tikalk fork). Agentic SDLC toolkit for Spec-Driven Development with pre-installed extensions and AI integrations."
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
Automated release of 0.5.5.

This PR was created by the Release Trigger workflow. The git tag `agentic-sdlc-v0.5.5` has already been pushed and the release artifacts are being built.

Merging this PR will set `main` to `0.5.6.dev0` so that development installs are clearly marked as pre-release.