### PR TITLE
fix: resolve bundled preset locator for agentic-sdlc in wheel/uv-tool installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Specify CLI and templates are documented here.
 
+# [0.10.0+adlc8] - 2026-06-12
+
+### Fixed
+
+- **`specify preset add agentic-sdlc` now works from wheel/uv-tool installs**: `_locate_bundled_preset()` was missing a fallback for the `bundled_presets/` directory where the fork's `agentic-sdlc` preset is packaged during wheel builds. Previously the command only succeeded in editable/source installs.
+
 # [1.0.10] - 2026-06-12
 
 ### Changed

--- a/FORK.md
+++ b/FORK.md
@@ -65,6 +65,7 @@ When a fork release changes only bundled extension behavior, keep the CLI versio
 
 | Version | Date | Base Upstream | Changes |
 |---------|------|---------------|---------|
+| 0.10.0+adlc8 | 2026-06-12 | 0.10.0 | Fixed `_locate_bundled_preset()` to resolve `agentic-sdlc` from `bundled_presets/` in wheel/uv-tool installs, matching the pyproject.toml wheel path. |
 | 0.10.0+adlc7 | 2026-06-12 | 0.10.0 | Agentic SDLC preset v1.0.10: trimmed duplicate `[SYNC]`/`[ASYNC]` taxonomies in `adlc.spec.plan.md` and `adlc.spec.tasks.md`; references canonical `templates/plan-template.md` and `templates/tasks-template.md` instead of inline duplication. ~340 tokens saved, behavior-identical. |
 | 0.10.0+adlc6 | 2026-06-08 | 0.10.0 | Repaired the bundled evals extension (PowerShell lifecycle parity, validation path fixes, non-interactive robustness) and promoted feature-local trace/verification into the preset surface: `spec.trace` owns `specs/{branch}/trace.md`, `spec.verify` defines `specs/{branch}/evidence.md`, and the Agentic SDLC preset now suggests trace/verify after implement. Evals extension bumped to v1.1.1, LevelUp stays at v1.7.1, preset bumped to v1.0.9. |
 | 0.10.0+adlc5 | 2026-06-08 | 0.10.0 | Added configurable git extension `branch_pattern` support with Jira issue keys, expanded git extension docs, added installed-extension end-to-end coverage for configured Jira branch names, bumped the bundled git extension to v1.5.0, and bumped the fork CLI release to capture the shipped behavior. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentic-sdlc-specify-cli"
-version = "0.10.0+adlc7"
+version = "0.10.0+adlc8"
 description = "Specify CLI (tikalk fork). Agentic SDLC toolkit for Spec-Driven Development with pre-installed extensions and AI integrations."
 requires-python = ">=3.11"
 dependencies = [

--- a/src/specify_cli/_assets.py
+++ b/src/specify_cli/_assets.py
@@ -137,6 +137,11 @@ def _locate_bundled_preset(preset_id: str) -> Path | None:
     if (candidate / "preset.yml").is_file():
         return candidate
 
+    # Wheel / uv tool install: Tikalk fork presets land in bundled_presets/
+    candidate = Path(__file__).parent / "bundled_presets" / preset_id
+    if (candidate / "preset.yml").is_file():
+        return candidate
+
     return None
 
 

--- a/tests/test_presets.py
+++ b/tests/test_presets.py
@@ -3847,6 +3847,14 @@ class TestBundledPresetLocator:
         assert _locate_bundled_preset("UPPERCASE") is None
         assert _locate_bundled_preset("has spaces") is None
 
+    def test_locate_bundled_agentic_sdlc_preset(self):
+        """_locate_bundled_preset finds the agentic-sdlc preset (fork bundled)."""
+        from specify_cli import _locate_bundled_preset
+
+        path = _locate_bundled_preset("agentic-sdlc")
+        assert path is not None
+        assert (path / "preset.yml").is_file()
+
     def test_bundled_preset_add_via_cli(self, project_dir):
         """Test that 'specify preset add lean' installs the bundled preset."""
         from typer.testing import CliRunner


### PR DESCRIPTION
## Summary

`_locate_bundled_preset()` in `src/specify_cli/_assets.py` only checked `core_pack/presets/` and `_repo_root()/presets/`, but the Tikalk fork bundles the `agentic-sdlc` preset into `bundled_presets/` (as declared in `pyproject.toml` line 40). This caused `specify preset add agentic-sdlc` to fail in wheel/uv-tool installs.

## Changes

- **`_assets.py`**: Added `bundled_presets/` fallback to `_locate_bundled_preset()`
- **`test_presets.py`**: Added `test_locate_bundled_agentic_sdlc_preset` regression test
- **`pyproject.toml`**: Bumped to `0.10.0+adlc8`
- **`CHANGELOG.md`**: Added `0.10.0+adlc8` entry
- **`FORK.md`**: Added version history row