### PR TITLE
feat: register team-discover hooks + add Skill Check step to preset commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to the Specify CLI and templates are documented here.
 
+# [0.12.15+adlc3] - 2026-07-15
+
+### Added
+
+- **Skill Check step in preset commands**: All 11 preset command files in
+  `agentic-sdlc` (9 `adlc.spec.*` + `adlc.spec.specify`) and `agentic-quick`
+  (`adlc.quick.implement`) now include a generic "Skill Check" step before the
+  extension hook checks. This bridges the ambient AGENTS.md "Strict Compliance"
+  directive ("You MUST check if a skill applies BEFORE responding") into the
+  command's procedural flow, preventing the "STOP. execute extension hooks"
+  tunnel from overriding it. The step is fully generic — it does not name
+  any specific skill.
+- **team-ai-directives discovery hooks**: The `team-ai-directives` extension
+  now declares `before_specify` and `before_plan` hooks (mandatory) in its
+  `extension.yml`. On install/update, `register_hooks()` writes these to
+  `.specify/extensions.yml`, so the spec workflow's existing hook-check logic
+  auto-invokes `/team.discover` before `/spec.specify` and `/spec.plan`.
+  Previously the hooks were documented in `team.discover.md` but never
+  declared in the manifest — leaving personas, rules, examples, and team
+  skills undiscovered.
+- **Test**: `test_team_ai_directives_declares_hooks` in
+  `test_bundled_extension_hooks.py` verifies the manifest declares both hooks
+  with the correct command and `optional: false`.
+
+### Changed
+
+- **Strengthened AGENTS.md injection**: The "Strict Compliance" bullet injected
+  by `update-agent-context.sh` / `.ps1` / `.py` now reads "This is not optional
+  and applies to every interaction" (previously just "If a skill applies, you
+  MUST invoke it immediately"). Makes the directive harder to deprioritize
+  against procedural command outlines.
+
+### Migration
+
+- Existing workspaces: run `specify extension update team-ai-directives` to
+  populate the new `before_specify` / `before_plan` hooks in
+  `.specify/extensions.yml`.
+
 # [0.12.15+adlc2] - 2026-07-15
 
 ### Changed

--- a/extensions/agent-context/scripts/bash/update-agent-context.sh
+++ b/extensions/agent-context/scripts/bash/update-agent-context.sh
@@ -374,7 +374,7 @@ trap 'rm -f "$TMP_SECTION"' EXIT
     echo "## Team Directives & Constitution"
     echo
     echo "This project is bound by the team-ai-directives knowledge base."
-    echo "- **Strict Compliance**: You MUST check if a skill applies BEFORE responding to any task or question. If a skill applies, you MUST invoke it immediately."
+    echo "- **Strict Compliance**: You MUST check if a skill applies BEFORE responding to any task or question. If a skill applies, you MUST invoke it immediately. This is not optional and applies to every interaction."
     echo "- **Team Constitution**: Read and strictly adhere to the principles in \`$TEAM_DIRECTIVES/context_modules/constitution.md\`. When creating or updating the project's constitution, you MUST inherit and align with these principles."
     echo "- **Rules, Personas & Examples**: Use the \`team-discover\` skill to find and load relevant rules, personas, or examples before making changes."
     echo

--- a/extensions/agent-context/scripts/powershell/update-agent-context.ps1
+++ b/extensions/agent-context/scripts/powershell/update-agent-context.ps1
@@ -478,7 +478,7 @@ if ($TeamDirectives) {
     $lines += '## Team Directives & Constitution'
     $lines += ''
     $lines += 'This project is bound by the team-ai-directives knowledge base.'
-    $lines += '- **Strict Compliance**: You MUST check if a skill applies BEFORE responding to any task or question. If a skill applies, you MUST invoke it immediately.'
+    $lines += '- **Strict Compliance**: You MUST check if a skill applies BEFORE responding to any task or question. If a skill applies, you MUST invoke it immediately. This is not optional and applies to every interaction.'
     $lines += "- **Team Constitution**: Read and strictly adhere to the principles in \`$TeamDirectives/context_modules/constitution.md\`. When creating or updating the project's constitution, you MUST inherit and align with these principles."
     $lines += "- **Rules, Personas & Examples**: Use the \`team-discover\` skill to find and load relevant rules, personas, or examples before making changes."
     $lines += ''

--- a/extensions/agent-context/scripts/python/update_agent_context.py
+++ b/extensions/agent-context/scripts/python/update_agent_context.py
@@ -218,7 +218,7 @@ def _build_section(
             "## Team Directives & Constitution",
             "",
             "This project is bound by the team-ai-directives knowledge base.",
-            "- **Strict Compliance**: You MUST check if a skill applies BEFORE responding to any task or question. If a skill applies, you MUST invoke it immediately.",
+            "- **Strict Compliance**: You MUST check if a skill applies BEFORE responding to any task or question. If a skill applies, you MUST invoke it immediately. This is not optional and applies to every interaction.",
             f"- **Team Constitution**: Read and strictly adhere to the principles in `{team_directives}/context_modules/constitution.md`. When creating or updating the project's constitution, you MUST inherit and align with these principles.",
             "- **Rules, Personas & Examples**: Use the `team-discover` skill to find and load relevant rules, personas, or examples before making changes.",
             "",

--- a/extensions/team-ai-directives/CHANGELOG.md
+++ b/extensions/team-ai-directives/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.2.0 - 2026-07-15
+
+- **Register discovery hooks**: Add `hooks:` block to `extension.yml` declaring `before_specify` and `before_plan` hooks (both mandatory, `optional: false`) pointing at `adlc.team-ai-directives.discover`. This makes `register_hooks(manifest)` populate `extensions.yml` during install/update, so the spec workflow's pre-execution hook checks auto-invoke team-discover before `/spec.specify` and `/spec.plan`. Previously the `team.discover.md` command file documented these hooks but the manifest never declared them — a documentation/reality gap that left team context (personas, rules, examples, skills) undiscovered.
+- **Migration**: Existing workspaces should run `specify extension update team-ai-directives` to write the new hooks to `.specify/extensions.yml`.
+
 ## 4.0.0 - 2026-07-09
 
 - Repackage team-ai-directives as a bundled spec-kit extension with governance commands and skills.

--- a/extensions/team-ai-directives/extension.yml
+++ b/extensions/team-ai-directives/extension.yml
@@ -3,7 +3,7 @@ schema_version: "1.0"
 extension:
   id: "team-ai-directives"
   name: "Team AI Directives"
-  version: "4.1.0"
+  version: "4.2.0"
   description: "Bundled governance extension for team-ai-directives: discover, curate, evolve, repair, verify, and manage team skills. Governance commands and skills are bundled here; domain skills remain in the external knowledge base."
   author: "Agentic SDLC Team"
   repository: "https://github.com/tikalk/agentic-sdlc-spec-kit"
@@ -61,6 +61,16 @@ handoffs:
       agent: "team.verify"
       prompt: "Run health checks on the repaired knowledge base"
       send: false
+
+hooks:
+  before_specify:
+    command: adlc.team-ai-directives.discover
+    optional: false
+    description: "Discover team context before specification"
+  before_plan:
+    command: adlc.team-ai-directives.discover
+    optional: false
+    description: "Discover team context before planning"
 
 tags:
   - "team-ai-directives"

--- a/presets/agentic-quick/commands/adlc.quick.implement.md
+++ b/presets/agentic-quick/commands/adlc.quick.implement.md
@@ -71,6 +71,8 @@ Display:
 
 **STOP. Before reading User Input or doing ANY other work, execute extension hooks.**
 
+**Skill Check**: Review the available skills listed in your system context. If any skill applies to this task, invoke it immediately via the skill tool and wait for its output before proceeding. This step enforces the "Strict Compliance" directive in AGENTS.md.
+
 1. If `{REPO_ROOT}/.specify/extensions.yml` does not exist, state `No hooks file found` and skip to User Input.
 2. Read `{REPO_ROOT}/.specify/extensions.yml` and find `hooks.before_implement`.
 3. Skip any hook with `enabled: false`. Skip any hook with a non-empty `condition`.

--- a/presets/agentic-sdlc/commands/adlc.spec.analyze.md
+++ b/presets/agentic-sdlc/commands/adlc.spec.analyze.md
@@ -10,6 +10,8 @@ scripts:
 
 **STOP. Before reading User Input or doing ANY other work, execute extension hooks.**
 
+**Skill Check**: Review the available skills listed in your system context. If any skill applies to this task, invoke it immediately via the skill tool and wait for its output before proceeding. This step enforces the "Strict Compliance" directive in AGENTS.md.
+
 0. Determine `{REPO_ROOT}` by running `git rev-parse --show-toplevel 2>/dev/null`. If that fails, walk up from the current directory until you find a `.git` directory or `.specify/init-options.json` and use that parent as `{REPO_ROOT}`.
 1. If `{REPO_ROOT}/.specify/extensions.yml` does not exist, state `No hooks file found` and skip to User Input.
    If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally.

--- a/presets/agentic-sdlc/commands/adlc.spec.brainstorm.md
+++ b/presets/agentic-sdlc/commands/adlc.spec.brainstorm.md
@@ -11,6 +11,8 @@ handoffs:
 
 **STOP. Before reading User Input or doing ANY other work, execute extension hooks.**
 
+**Skill Check**: Review the available skills listed in your system context. If any skill applies to this task, invoke it immediately via the skill tool and wait for its output before proceeding. This step enforces the "Strict Compliance" directive in AGENTS.md.
+
 0. Determine `{REPO_ROOT}` by running `git rev-parse --show-toplevel 2>/dev/null`. If that fails, walk up from the current directory until you find a `.git` directory or `.specify/init-options.json` and use that parent as `{REPO_ROOT}`.
 1. If `{REPO_ROOT}/.specify/extensions.yml` does not exist, state `No hooks file found` and skip to User Input.
    If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally.

--- a/presets/agentic-sdlc/commands/adlc.spec.checklist.md
+++ b/presets/agentic-sdlc/commands/adlc.spec.checklist.md
@@ -29,6 +29,8 @@ scripts:
 
 **STOP. Before reading User Input or doing ANY other work, execute extension hooks.**
 
+**Skill Check**: Review the available skills listed in your system context. If any skill applies to this task, invoke it immediately via the skill tool and wait for its output before proceeding. This step enforces the "Strict Compliance" directive in AGENTS.md.
+
 0. Determine `{REPO_ROOT}` by running `git rev-parse --show-toplevel 2>/dev/null`. If that fails, walk up from the current directory until you find a `.git` directory or `.specify/init-options.json` and use that parent as `{REPO_ROOT}`.
 1. If `{REPO_ROOT}/.specify/extensions.yml` does not exist, state `No hooks file found` and skip to User Input.
    If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally.

--- a/presets/agentic-sdlc/commands/adlc.spec.clarify.md
+++ b/presets/agentic-sdlc/commands/adlc.spec.clarify.md
@@ -14,6 +14,8 @@ scripts:
 
 **STOP. Before reading User Input or doing ANY other work, execute extension hooks.**
 
+**Skill Check**: Review the available skills listed in your system context. If any skill applies to this task, invoke it immediately via the skill tool and wait for its output before proceeding. This step enforces the "Strict Compliance" directive in AGENTS.md.
+
 0. Determine `{REPO_ROOT}` by running `git rev-parse --show-toplevel 2>/dev/null`. If that fails, walk up from the current directory until you find a `.git` directory or `.specify/init-options.json` and use that parent as `{REPO_ROOT}`.
 1. If `{REPO_ROOT}/.specify/extensions.yml` does not exist, state `No hooks file found` and skip to User Input.
    If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally.

--- a/presets/agentic-sdlc/commands/adlc.spec.constitution.md
+++ b/presets/agentic-sdlc/commands/adlc.spec.constitution.md
@@ -10,6 +10,8 @@ handoffs:
 
 **STOP. Before reading User Input or doing ANY other work, execute extension hooks.**
 
+**Skill Check**: Review the available skills listed in your system context. If any skill applies to this task, invoke it immediately via the skill tool and wait for its output before proceeding. This step enforces the "Strict Compliance" directive in AGENTS.md.
+
 0. Determine `{REPO_ROOT}` by running `git rev-parse --show-toplevel 2>/dev/null`. If that fails, walk up from the current directory until you find a `.git` directory or `.specify/init-options.json` and use that parent as `{REPO_ROOT}`.
 1. If `{REPO_ROOT}/.specify/extensions.yml` does not exist, state `No hooks file found` and skip to User Input.
    If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally.

--- a/presets/agentic-sdlc/commands/adlc.spec.converge.md
+++ b/presets/agentic-sdlc/commands/adlc.spec.converge.md
@@ -10,6 +10,8 @@ scripts:
 
 **STOP. Before reading User Input or doing ANY other work, execute extension hooks.**
 
+**Skill Check**: Review the available skills listed in your system context. If any skill applies to this task, invoke it immediately via the skill tool and wait for its output before proceeding. This step enforces the "Strict Compliance" directive in AGENTS.md.
+
 0. Determine `{REPO_ROOT}` by running `git rev-parse --show-toplevel 2>/dev/null`. If that fails, walk up from the current directory until you find a `.git` directory or `.specify/init-options.json` and use that parent as `{REPO_ROOT}`.
 1. If `{REPO_ROOT}/.specify/extensions.yml` does not exist, state `No hooks file found` and skip to User Input.
    If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally.

--- a/presets/agentic-sdlc/commands/adlc.spec.implement.md
+++ b/presets/agentic-sdlc/commands/adlc.spec.implement.md
@@ -17,6 +17,8 @@ scripts:
 
 **STOP. Before reading User Input or doing ANY other work, execute extension hooks.**
 
+**Skill Check**: Review the available skills listed in your system context. If any skill applies to this task, invoke it immediately via the skill tool and wait for its output before proceeding. This step enforces the "Strict Compliance" directive in AGENTS.md.
+
 0. Determine `{REPO_ROOT}` by running `git rev-parse --show-toplevel 2>/dev/null`. If that fails, walk up from the current directory until you find a `.git` directory or `.specify/init-options.json` and use that parent as `{REPO_ROOT}`.
 1. If `{REPO_ROOT}/.specify/extensions.yml` does not exist, state `No hooks file found` and skip to User Input.
    If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally.

--- a/presets/agentic-sdlc/commands/adlc.spec.plan.md
+++ b/presets/agentic-sdlc/commands/adlc.spec.plan.md
@@ -17,6 +17,8 @@ scripts:
 
 **STOP. Before reading User Input or doing ANY other work, execute extension hooks.**
 
+**Skill Check**: Review the available skills listed in your system context. If any skill applies to this task, invoke it immediately via the skill tool and wait for its output before proceeding. This step enforces the "Strict Compliance" directive in AGENTS.md.
+
 0. Determine `{REPO_ROOT}` by running `git rev-parse --show-toplevel 2>/dev/null`. If that fails, walk up from the current directory until you find a `.git` directory or `.specify/init-options.json` and use that parent as `{REPO_ROOT}`.
 1. If `{REPO_ROOT}/.specify/extensions.yml` does not exist, state `No hooks file found` and skip to User Input.
    If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally.

--- a/presets/agentic-sdlc/commands/adlc.spec.specify.md
+++ b/presets/agentic-sdlc/commands/adlc.spec.specify.md
@@ -21,6 +21,8 @@ scripts:
 
 **Execute ONLY read-only discovery hooks.**
 
+**Skill Check**: Review the available skills listed in your system context. If any skill applies to this task, invoke it immediately via the skill tool and wait for its output before proceeding. This step enforces the "Strict Compliance" directive in AGENTS.md.
+
 0. Determine `{REPO_ROOT}` by running `git rev-parse --show-toplevel 2>/dev/null`. If that fails, walk up from the current directory until you find a `.git` directory or `.specify/init-options.json` and use that parent as `{REPO_ROOT}`.
 1. If `{REPO_ROOT}/.specify/extensions.yml` does not exist, state `No hooks file found` and skip to Mission Brief Extraction.
 2. Read `{REPO_ROOT}/.specify/extensions.yml` and find `hooks.before_specify`.

--- a/presets/agentic-sdlc/commands/adlc.spec.tasks.md
+++ b/presets/agentic-sdlc/commands/adlc.spec.tasks.md
@@ -19,6 +19,8 @@ scripts:
 
 **STOP. Before reading User Input or doing ANY other work, execute extension hooks.**
 
+**Skill Check**: Review the available skills listed in your system context. If any skill applies to this task, invoke it immediately via the skill tool and wait for its output before proceeding. This step enforces the "Strict Compliance" directive in AGENTS.md.
+
 0. Determine `{REPO_ROOT}` by running `git rev-parse --show-toplevel 2>/dev/null`. If that fails, walk up from the current directory until you find a `.git` directory or `.specify/init-options.json` and use that parent as `{REPO_ROOT}`.
 1. If `{REPO_ROOT}/.specify/extensions.yml` does not exist, state `No hooks file found` and skip to User Input.
    If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentic-sdlc-specify-cli"
-version = "0.12.15+adlc2"
+version = "0.12.15+adlc3"
 description = "Specify CLI (tikalk fork). Agentic SDLC toolkit for Spec-Driven Development with pre-installed extensions and AI integrations."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_bundled_extension_hooks.py
+++ b/tests/test_bundled_extension_hooks.py
@@ -253,3 +253,45 @@ def test_hook_update_replaces_existing_hook(temp_project, extension_with_hooks):
 
     assert before_hook["description"] == "Updated description"
     assert before_hook["optional"] is True  # Should be updated
+
+
+def test_team_ai_directives_declares_hooks():
+    """Test that the bundled team-ai-directives extension declares hooks.
+
+    The extension must register before_specify and before_plan hooks so that
+    team-discover is auto-invoked by the spec workflow's pre-execution hook
+    checks. Without these declarations, register_hooks() writes nothing and
+    the agent never triggers team-discover during /spec.specify or /spec.plan.
+    """
+    ext_yml = (
+        Path(__file__).resolve().parent.parent
+        / "extensions"
+        / "team-ai-directives"
+        / "extension.yml"
+    )
+    assert ext_yml.exists(), "team-ai-directives/extension.yml must exist"
+
+    manifest = yaml.safe_load(ext_yml.read_text())
+    assert "hooks" in manifest, (
+        "team-ai-directives extension.yml must declare a 'hooks' block "
+        "so that register_hooks() populates extensions.yml during install"
+    )
+
+    hooks = manifest["hooks"]
+    assert "before_specify" in hooks, (
+        "team-ai-directives must register a before_specify hook to auto-invoke "
+        "team-discover before /spec.specify"
+    )
+    assert hooks["before_specify"]["command"] == "adlc.team-ai-directives.discover"
+    assert hooks["before_specify"]["optional"] is False, (
+        "before_specify hook should be mandatory (optional: false)"
+    )
+
+    assert "before_plan" in hooks, (
+        "team-ai-directives must register a before_plan hook to auto-invoke "
+        "team-discover before /spec.plan"
+    )
+    assert hooks["before_plan"]["command"] == "adlc.team-ai-directives.discover"
+    assert hooks["before_plan"]["optional"] is False, (
+        "before_plan hook should be mandatory (optional: false)"
+    )


### PR DESCRIPTION
## Summary

The `team-ai-directives` extension declared no hooks in its `extension.yml`, so `register_hooks()` wrote nothing for `before_specify`/`before_plan`. The `team.discover.md` command documented these hooks but the manifest never declared them — leaving personas, rules, examples, and team skills undiscovered during `/spec.specify` and `/spec.plan`.

This was found by reviewing a session trace of `/spec.constitution` and `/spec.specify` where team skills were never triggered despite the AGENTS.md injection being present.

## Changes

### Part 1: Register team-discover hooks (`extensions/team-ai-directives/extension.yml`)
- Added `hooks:` block with mandatory `before_specify` + `before_plan` hooks (`optional: false`) pointing at `adlc.team-ai-directives.discover`.
- On install/update, `register_hooks(manifest)` now writes these to `.specify/extensions.yml`, so the spec workflow's existing pre-execution hook checks auto-invoke `/team.discover`.
- Bumped extension version to `4.2.0`.

### Part 2: Add generic Skill Check step to 11 preset command files
- All preset commands in `agentic-sdlc` (9 `adlc.spec.*` + `adlc.spec.specify`) and `agentic-quick` (`adlc.quick.implement`) now include a generic "Skill Check" step before the extension hook checks.
- This bridges the ambient AGENTS.md "Strict Compliance" directive into the command's procedural flow, preventing the "STOP. execute extension hooks" tunnel from overriding it.
- **Fully generic** — does not name any specific skill.

### Part 3: Strengthen AGENTS.md injection text
- `update-agent-context.sh` / `.ps1` / `.py`: strengthened "Strict Compliance" bullet with "This is not optional and applies to every interaction."

### Part 4: Tests, CHANGELOGs, version bump
- `test_team_ai_directives_declares_hooks`: verifies manifest declares both hooks with correct command and `optional: false`.
- Root CHANGELOG: `0.12.15+adlc3` entry.
- `extensions/team-ai-directives/CHANGELOG.md`: `4.2.0` entry.
- `pyproject.toml`: version bump to `0.12.15+adlc3`.

## Test plan
- [x] `test_team_ai_directives_declares_hooks` passes
- [x] 425 tests pass (`test_bundled_extension_hooks.py` + `test_extensions.py` + `test_extension_registration.py` + `test_agent_config_consistency.py`)
- [ ] Manual: run `specify extension update team-ai-directives` in a workspace with team-ai-directives installed, verify `before_specify` and `before_plan` hooks appear in `.specify/extensions.yml`

## Migration

Existing workspaces: run `specify extension update team-ai-directives` to populate the new `before_specify` / `before_plan` hooks in `.specify/extensions.yml`.

Assisted-by: opencode (model: glm-5.2, supervised)